### PR TITLE
Fix incorrect usage of `~a` in `printf` and `convert` functions

### DIFF
--- a/pomelo/utils.rkt
+++ b/pomelo/utils.rkt
@@ -104,12 +104,12 @@
         (printf "+~a+\n" (make-string total-width #\-))
         (for ([item stack] [i (in-range (length stack))])
           (printf "| ~a | ~a |\n" 
-                  (string-pad-left (~a i) max-index-width) 
-                  (string-pad-right (~a item) max-item-width))) ; 使用 convert 函数
+                  (string-pad-left (number->string i) max-index-width) 
+                  (string-pad-right (convert item) max-item-width))) ; Use convert function
         (printf "+~a+\n" (make-string total-width #\-)))))
 
 (define (convert obj)
-  (pretty-format (read (open-input-string (~a obj)))))
+  (pretty-format (read (open-input-string (format "~a" obj)))))
 
 (define (string-pad-left s n [c #\space])
   (define l (string-length s))


### PR DESCRIPTION
Resolves issues related to the improper use of the `~a` format specifier within the `printf` and `convert` functions. The changes ensure correct string formatting and eliminate potential runtime errors caused by treating `~a` as a function.

Closes #5 